### PR TITLE
Add the ability to filter the reviewed pull requests

### DIFF
--- a/scripts/controls/filters.tsx
+++ b/scripts/controls/filters.tsx
@@ -10,17 +10,17 @@ import { CompletionDropdown } from "./CompletionDropdown";
 import { IdentityPicker } from "./IdentityPicker";
 
 /** Toggle except it adds a the css class 'focus' to the container when the toggle is focused */
-class FocusToggle extends React.Component<IToggleProps, {focus: boolean}> {
+class FocusToggle extends React.Component<IToggleProps, { focus: boolean }> {
   constructor(props: IToggleProps) {
     super(props);
-    this.state = {focus: false};
+    this.state = { focus: false };
   }
   render() {
     const classes = this.props.className || "";
     return <Toggle {...this.props}
-      className={this.state.focus ? `focus ${classes}`: classes}
-      onFocus={() => this.setState({focus: true})}
-      onBlur={() => this.setState({focus: false})}
+      className={this.state.focus ? `focus ${classes}` : classes}
+      onFocus={() => this.setState({ focus: true })}
+      onBlur={() => this.setState({ focus: false })}
     />;
   }
 }
@@ -47,7 +47,7 @@ interface IFiltersProps {
 
 class Filters extends React.Component<
   IFiltersProps, {}
-> {
+  > {
   render() {
     const filter = this.props.filter;
     const providerToggleProps = {
@@ -70,7 +70,8 @@ class Filters extends React.Component<
           }} />
           <ProviderToggle {...providerToggleProps} label={"Commits"} provider={"Commit"} />
           <ProviderToggle {...providerToggleProps} label={"Created pull requests"} provider={"CreatePullRequest"} />
-          <ProviderToggle {...providerToggleProps} label={"Closed pull requests"}  provider={"ClosePullRequest"} />
+          <ProviderToggle {...providerToggleProps} label={"Closed pull requests"} provider={"ClosePullRequest"} />
+          <ProviderToggle {...providerToggleProps} label={"Reviewed pull requests"} provider={"ReviewPullRequest"} />
           <ProviderToggle {...providerToggleProps} label={"Created work items"} provider={"CreateWorkItem"} />
           <ProviderToggle {...providerToggleProps} label={"Resolved work items"} provider={"ResolveWorkItem"} />
           <ProviderToggle {...providerToggleProps} label={"Closed work items"} provider={"CloseWorkItem"} />
@@ -79,7 +80,7 @@ class Filters extends React.Component<
             label="Repository"
             selected={filter.repositories}
             resolveSuggestions={(search, selected) => searchRepositories(filter.allProjects, search, selected)}
-            onSelectionChanged={repositories => this.updateFilter({repositories})}
+            onSelectionChanged={repositories => this.updateFilter({ repositories })}
             placeholder={"Search repositories..."}
           />
         </div>
@@ -93,18 +94,18 @@ class Filters extends React.Component<
             className="filter-header"
             level={4}
           >
-          {collapsibleContent}
+            {collapsibleContent}
           </CollapsibleHeader> : collapsibleContent
         }
       </div>
     );
   }
   updateFilter(filter: Partial<IContributionFilter>) {
-    const updatedFilter = {...this.props.filter, ...filter};
+    const updatedFilter = { ...this.props.filter, ...filter };
     this.props.onChanged(updatedFilter);
   }
   updateProvider(provider: ContributionName, enabled: boolean) {
-    const filter = {enabledProviders: {...this.props.filter.enabledProviders}};
+    const filter = { enabledProviders: { ...this.props.filter.enabledProviders } };
     filter.enabledProviders[provider] = enabled;
     this.updateFilter(filter);
   }
@@ -117,7 +118,7 @@ export function renderFilters(
   collapsible: boolean = true,
   callback?: () => void,
 ) {
-  const props = {onChanged, filter: initialFilter, collapsible};
+  const props = { onChanged, filter: initialFilter, collapsible };
   const graphParent = $(".filter-container")[0];
   ReactDOM.render(
     <Filters {...props} />,

--- a/scripts/data/contracts.ts
+++ b/scripts/data/contracts.ts
@@ -53,6 +53,13 @@ export class ClosePullRequestContribution extends PullRequestContribution {
     }
 }
 
+export class ReviewPullRequestContribution extends PullRequestContribution {
+    constructor(pullrequest: GitPullRequest) {
+        // TODO: Is there a better date to put here than the Closed Date?
+        super(`pr-review-${pullrequest.pullRequestId}`, pullrequest.closedDate, pullrequest);
+    }
+}
+
 export abstract class WorkItemContribution extends UserContribution {
     constructor(id: string, dateStr: string, readonly wi: WorkItem) {
         super(id, new Date(dateStr));

--- a/scripts/data/git/pullrequests.ts
+++ b/scripts/data/git/pullrequests.ts
@@ -32,7 +32,7 @@ function toRepoMap(repos: GitRepository[]): { [id: string]: GitRepository } {
     return map;
 }
 const batchSize = 101;
-function getPullRequestsForRepository(username: string, repoId: string, searchCriteria: GitPullRequestSearchCriteria, skip = 0): Promise<GitPullRequest[]> {
+function getPullRequestsForRepository(repoId: string, searchCriteria: GitPullRequestSearchCriteria, skip = 0): Promise<GitPullRequest[]> {
     return Promise.all([
         getClient().getPullRequests(repoId, searchCriteria, undefined, 0, skip, batchSize),
         repositoriesVal.getValue()
@@ -46,7 +46,7 @@ function getPullRequestsForRepository(username: string, repoId: string, searchCr
         if (pullrequests.length < batchSize) {
             return pullrequests;
         }
-        return getPullRequestsForRepository(username, repoId, searchCriteria, skip + batchSize).then(morePullrequests =>
+        return getPullRequestsForRepository(repoId, searchCriteria, skip + batchSize).then(morePullrequests =>
             [...pullrequests, ...morePullrequests]);
 
     });
@@ -89,7 +89,7 @@ export async function getCreatedPullRequests(filter: IIndividualContributionFilt
     } as GitPullRequestSearchCriteria;
     for (const { key: repoId } of filter.repositories) {
         if (!(repoId in createdPrs[username])) {
-            createdPrs[username][repoId] = getPullRequestsForRepository(username, repoId, searchCriteria);
+            createdPrs[username][repoId] = getPullRequestsForRepository(repoId, searchCriteria);
         }
         prProms.push(createdPrs[username][repoId]);
     }
@@ -114,7 +114,7 @@ export async function getReviewedPullRequests(filter: IIndividualContributionFil
     } as GitPullRequestSearchCriteria;
     for (const { key: repoId } of filter.repositories) {
         if (!(repoId in reviewedPrs[username])) {
-            reviewedPrs[username][repoId] = getPullRequestsForRepository(username, repoId, searchCriteria);
+            reviewedPrs[username][repoId] = getPullRequestsForRepository(repoId, searchCriteria);
         }
         prProms.push(reviewedPrs[username][repoId]);
     }

--- a/scripts/data/git/pullrequests.ts
+++ b/scripts/data/git/pullrequests.ts
@@ -60,7 +60,7 @@ function getPullRequestsForRepository(username: string, repoId: string, skip = 0
 function getReviewedPullRequestsForRepository(username: string, repoId: string, skip = 0): Promise<GitPullRequest[]> {
     const criteria = {
         reviewerId: username,
-        status: PullRequestStatus.Completed,
+        status: PullRequestStatus.All,
     } as GitPullRequestSearchCriteria;
 
     return Promise.all([

--- a/scripts/filter.ts
+++ b/scripts/filter.ts
@@ -4,13 +4,14 @@ import { CachedValue } from "./data/CachedValue";
 import { defaultRepostory } from "./data/git/repositories";
 
 export interface IEnabledProviders {
-    Commit: boolean;
-    CreatePullRequest: boolean;
-    ClosePullRequest: boolean;
-    CreateWorkItem: boolean;
-    CloseWorkItem: boolean;
-    ResolveWorkItem: boolean;
-    Changeset: boolean;
+  Commit: boolean;
+  CreatePullRequest: boolean;
+  ClosePullRequest: boolean;
+  ReviewPullRequest: boolean;
+  CreateWorkItem: boolean;
+  CloseWorkItem: boolean;
+  ResolveWorkItem: boolean;
+  Changeset: boolean;
 }
 
 export interface ISelectedRange {
@@ -19,44 +20,44 @@ export interface ISelectedRange {
 }
 
 export interface IContributionFilter {
-    identities: IIdentity[];
-    allProjects: boolean;
-    enabledProviders: IEnabledProviders;
-    repositories: {key: string; name: string}[];
+  identities: IIdentity[];
+  allProjects: boolean;
+  enabledProviders: IEnabledProviders;
+  repositories: { key: string; name: string }[];
 }
 
 export interface IIndividualContributionFilter {
   identity: IIdentity;
   allProjects: boolean;
   enabledProviders: IEnabledProviders;
-  repositories: {key: string; name: string}[];
+  repositories: { key: string; name: string }[];
 }
 
 export function deepEqual(x, y): boolean {
   return (x && y && typeof x === 'object' && typeof y === 'object') ?
     (Object.keys(x).length === Object.keys(y).length) &&
-      Object.keys(x).reduce(function(isEqual, key) {
-        return isEqual && deepEqual(x[key], y[key]);
-      }, true) : (x === y);
+    Object.keys(x).reduce(function (isEqual, key) {
+      return isEqual && deepEqual(x[key], y[key]);
+    }, true) : (x === y);
 }
 
 export function filterToIProperties(filter: IContributionFilter): IProperties {
-    const properties: IProperties = {};
-    for (let providerKey in filter.enabledProviders) {
-        properties[providerKey] = String(filter.enabledProviders[providerKey]);
-    }
-    properties["allProjects"] = String(!!filter.allProjects);
-    properties["identityCount"] = filter.identities.length + "";
-    properties["plainTextIdentityCount"] = filter.identities.filter(({id}) => !id).length + "";
-    return properties;
+  const properties: IProperties = {};
+  for (let providerKey in filter.enabledProviders) {
+    properties[providerKey] = String(filter.enabledProviders[providerKey]);
+  }
+  properties["allProjects"] = String(!!filter.allProjects);
+  properties["identityCount"] = filter.identities.length + "";
+  properties["plainTextIdentityCount"] = filter.identities.filter(({ id }) => !id).length + "";
+  return properties;
 }
 
 export const defaultFilter: CachedValue<IContributionFilter> = new CachedValue(getDefaultFilter);
 async function getDefaultFilter(): Promise<IContributionFilter> {
   const defaultRepo = await defaultRepostory.getValue();
-  const repositories: {key: string, name: string}[] = [];
+  const repositories: { key: string, name: string }[] = [];
   if (defaultRepo) {
-    repositories.push({key: defaultRepo.id, name: defaultRepo.name});
+    repositories.push({ key: defaultRepo.id, name: defaultRepo.name });
   }
   const filter: IContributionFilter = {
     identities: [{
@@ -71,6 +72,7 @@ async function getDefaultFilter(): Promise<IContributionFilter> {
       Commit: true,
       CreatePullRequest: true,
       ClosePullRequest: true,
+      ReviewPullRequest: true,
       CloseWorkItem: true,
       CreateWorkItem: true,
       ResolveWorkItem: true,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail if necessary -->
This feature will allow the user to filter on the reviewed pull requests of the selected identities by a new toggle. A reviewed pull request is counted if the identities selected are part of the reviewers of a pull request.

## Screenshot of changes
<!-- Include screenshots of all new scenarios -->
(Currently trying to publish it to our azure devops to test it.)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Adds the ability to see reviewed pull requests of each user. Simply adds value to the extension.
<!--- If it fixes an open issue, please link to the issue here. -->
#35 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

