### PR TITLE
Add toggle to apply a shared scale across all individual graphs

### DIFF
--- a/scripts/controls/Graphs.tsx
+++ b/scripts/controls/Graphs.tsx
@@ -6,12 +6,24 @@ import { Graph } from "./Graph";
 export class Graphs extends React.Component<{
     contributions: IUserContributions[],
     loading: boolean,
+    sharedScale: boolean
 }, {}> {
     public render() {
+        let overrideLargest = 0;
+        if (this.props.sharedScale) {
+            let largests = this.props.contributions.map((contributions) => {
+                const counts: number[] = Object.keys(contributions.data).map(day => contributions.data[day].length);
+                counts.sort((a, b) => a - b);
+                return counts.length ?  counts[counts.length - 1] : 0;
+            });
+            largests.sort((a, b) => a - b);
+            overrideLargest = largests[largests.length - 1];
+        }
         return <div className="graphs">
             {this.props.contributions.map((contributions) => <Graph
                 contributions={contributions}
                 loading={this.props.loading}
+                overrideLargest={overrideLargest}
             />)}
         </div>;
     }

--- a/scripts/controls/filters.tsx
+++ b/scripts/controls/filters.tsx
@@ -68,6 +68,9 @@ class Filters extends React.Component<
           <FocusToggle checked={filter.allProjects} label={"All projects"} onChanged={checked => {
             this.updateFilter({ allProjects: checked });
           }} />
+          <FocusToggle checked={filter.sharedScale} label={"Shared Scale"} onChanged={checked => {
+            this.updateFilter({ sharedScale: checked });
+          }} />
           <ProviderToggle {...providerToggleProps} label={"Commits"} provider={"Commit"} />
           <ProviderToggle {...providerToggleProps} label={"Created pull requests"} provider={"CreatePullRequest"} />
           <ProviderToggle {...providerToggleProps} label={"Closed pull requests"} provider={"ClosePullRequest"} />

--- a/scripts/controls/graph.tsx
+++ b/scripts/controls/graph.tsx
@@ -8,7 +8,7 @@ import { ISelectedRange } from "../filter";
 import { Day } from "./Day";
 import { TimeWindow } from "./timeWindow/timeWindow";
 
-function getContributionClassDelegate(contributions: IUserContributions): (count: number) => string {
+function getContributionClassDelegate(contributions: IUserContributions, overrideLargest: number): (count: number) => string {
     const counts: number[] = Object.keys(contributions.data)
         .map(day => contributions.data[day].length);
     if (counts.length === 0) {
@@ -20,7 +20,7 @@ function getContributionClassDelegate(contributions: IUserContributions): (count
         [0.50, "work_50"],
         [0.75, "work_75"]
     ];
-    const largest = counts[counts.length - 1];
+    const largest = overrideLargest || counts[counts.length - 1];
     // convert the percentiles to their values for the inputs
     for (const threshold of thresholds) {
         threshold[0] = Math.floor(threshold[0] * largest);
@@ -57,6 +57,7 @@ const monthNames: string[] = [
 export class Graph extends React.Component<{
     contributions: IUserContributions,
     loading: boolean,
+    overrideLargest:number
 }, {
     selected?: ISelectedRange,
 }> {
@@ -65,7 +66,7 @@ export class Graph extends React.Component<{
         this.state = {};
     }
     render() {
-        const getWorkClass = getContributionClassDelegate(this.props.contributions);
+        const getWorkClass = getContributionClassDelegate(this.props.contributions, this.props.overrideLargest);
         const date = new Date();
         date.setHours(0, 0, 0, 0);
         date.setDate(date.getDate() - date.getDay());

--- a/scripts/controls/showGraphs.tsx
+++ b/scripts/controls/showGraphs.tsx
@@ -21,6 +21,7 @@ export function renderGraphs(filter: IContributionFilter) {
             ReactDOM.render(<Graphs
                 contributions={loadingContributions}
                 loading={true}
+                sharedScale={false}
             />, graphParent,
             () => {
                 timings.measure("drawSpinner");
@@ -35,6 +36,7 @@ export function renderGraphs(filter: IContributionFilter) {
             ReactDOM.render(<Graphs
                 contributions={contributions}
                 loading={false}
+                sharedScale={filter.sharedScale}
             />, graphParent, () => {
                 timings.measure("drawGraph");
                 trackEvent("loadGraph", filterToIProperties(filter), timings.measurements);

--- a/scripts/data/provider.ts
+++ b/scripts/data/provider.ts
@@ -67,6 +67,7 @@ export function getContributions(filter: IContributionFilter): Promise<IUserCont
         const individualFilter: IIndividualContributionFilter = {
             identity,
             allProjects: filter.allProjects,
+            sharedScale: filter.sharedScale,
             enabledProviders: filter.enabledProviders,
             repositories: filter.repositories,
         };

--- a/scripts/filter.ts
+++ b/scripts/filter.ts
@@ -22,6 +22,7 @@ export interface ISelectedRange {
 export interface IContributionFilter {
   identities: IIdentity[];
   allProjects: boolean;
+  sharedScale: boolean;
   enabledProviders: IEnabledProviders;
   repositories: { key: string; name: string }[];
 }
@@ -29,6 +30,7 @@ export interface IContributionFilter {
 export interface IIndividualContributionFilter {
   identity: IIdentity;
   allProjects: boolean;
+  sharedScale: boolean;
   enabledProviders: IEnabledProviders;
   repositories: { key: string; name: string }[];
 }
@@ -47,6 +49,7 @@ export function filterToIProperties(filter: IContributionFilter): IProperties {
     properties[providerKey] = String(filter.enabledProviders[providerKey]);
   }
   properties["allProjects"] = String(!!filter.allProjects);
+  properties["sharedScale"] = String(!!filter.sharedScale);
   properties["identityCount"] = filter.identities.length + "";
   properties["plainTextIdentityCount"] = filter.identities.filter(({ id }) => !id).length + "";
   return properties;
@@ -68,6 +71,7 @@ async function getDefaultFilter(): Promise<IContributionFilter> {
         .uri}_api/_common/identityImage?size=2&id=${VSS.getWebContext().user.id}`
     }],
     allProjects: false,
+    sharedScale: false,
     enabledProviders: {
       Commit: true,
       CreatePullRequest: true,


### PR DESCRIPTION
## Description
Include a new toggle to override the scale of individual graphs with the largest scale across all graphs so that they can be compared relatively.

## Motivation and Context
Fixes #29 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

